### PR TITLE
Fixed request body validation and response body valdiation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 *.log
+launch.json
+.DS_Store

--- a/examples/external-ref/post-character.json
+++ b/examples/external-ref/post-character.json
@@ -2,11 +2,19 @@
   "operationId": "postCharacter",
   "parameters": [
     {
-      "name": "name",
+      "name": "body",
       "in": "body",
       "required": true,
       "schema": {
-        "type": "string"
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
       }
     }
   ],

--- a/examples/internal-ref/index.js
+++ b/examples/internal-ref/index.js
@@ -14,7 +14,10 @@ app.use(
     operations: {greet},
     onRequestValidationError: (req, res, errors, next) => {
       res.status(400).json({errors})
-    }
+    },
+    onResponseValidationError: (req, res, errors, next) => {
+      res.status(400).json({errors})
+    },
   })
 )
 

--- a/examples/stranger-things/api.json
+++ b/examples/stranger-things/api.json
@@ -24,11 +24,20 @@
         "operationId": "postCharacter",
         "parameters": [
           {
-            "name": "name",
+            "name": "body",
             "in": "body",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "properties": {
+
+                "name": {
+                  "type": "string"
+                }
+              }
             }
           }
         ],

--- a/lib/load-specification.js
+++ b/lib/load-specification.js
@@ -38,7 +38,7 @@ app.use(confident({
 
   // resolve external refs
   const withResolvedExternalRefs = cloneDeepWith(apiSpecification, value => {
-    if (typeof value === 'object' && value.$ref) {
+    if (value != null && typeof value === 'object' && value.$ref) {
       const refParts = value.$ref.split('#')
       const file = refParts[0]
       const pointer = refParts[1]
@@ -60,7 +60,7 @@ app.use(confident({
   const withResolvedInternalRefs = cloneDeepWith(
     withResolvedExternalRefs,
     value => {
-      if (typeof value === 'object' && value.$ref) {
+      if (value != null && typeof value === 'object' && value.$ref) {
         const refParts = value.$ref.split('#')
         const pointer = refParts[1]
         return jsonpointer.get(withResolvedExternalRefs, pointer)

--- a/lib/utils/load-refs.js
+++ b/lib/utils/load-refs.js
@@ -1,0 +1,9 @@
+
+module.exports = function ({ajv, apiDefinition}) {
+  for (let definitionSchema in apiDefinition.definitions) {
+    ajv.addSchema(apiDefinition.definitions[definitionSchema], '#/definitions/' + definitionSchema)
+  }
+  for (let responseSchema in apiDefinition.responses) {
+    ajv.addSchema(apiDefinition.responses[responseSchema].schema, '#/responses/' + responseSchema)
+  }
+}

--- a/lib/validate-request.js
+++ b/lib/validate-request.js
@@ -11,6 +11,11 @@ module.exports = (
   requestValidationErrorHandler
 ) => {
   const ajv = new Ajv(Object.assign({}, {removeAdditional: true}, ajvOptions))
+
+  for (let definitionSchema in apiDefinition.definitions) {
+    ajv.addSchema(apiDefinition.definitions[definitionSchema], '#/definitions/' + definitionSchema)
+  }
+
   const requestValidationRouter = express.Router({mergeParams: true})
 
   for (let path in apiDefinition.paths) {
@@ -106,7 +111,11 @@ module.exports = (
       const expressFriendlyPath = path
         .replace(/\/{/g, '/:')
         .replace(new RegExp('}', 'g'), '')
-      requestValidationRouter[method](expressFriendlyPath, validateRequest)
+        
+        if (requestValidationRouter[method]) {
+          requestValidationRouter[method](expressFriendlyPath, validateRequest)
+        }
+
       if (methodInfo.operationId) {
         if (!operations[methodInfo.operationId]) {
           console.log(

--- a/lib/validate-request.js
+++ b/lib/validate-request.js
@@ -12,11 +12,6 @@ module.exports = (
   requestValidationErrorHandler
 ) => {
   const ajv = new Ajv(Object.assign({}, {removeAdditional: true}, ajvOptions))
-
-  for (let definitionSchema in apiDefinition.definitions) {
-    ajv.addSchema(apiDefinition.definitions[definitionSchema], '#/definitions/' + definitionSchema)
-  }
-
   const requestValidationRouter = express.Router({mergeParams: true})
   loadRefs({ajv, apiDefinition})
 

--- a/lib/validate-request.js
+++ b/lib/validate-request.js
@@ -30,16 +30,18 @@ module.exports = (
           const schema = Object.assign({}, param.schema || {})
           return [param.name, schema]
         })
+        
       if (bodyPropertySchemas.length) {
-        const required = methodInfo.parameters
-          .filter(inBody)
-          .filter(param => param.required)
-          .map(param => param.name)
-        const bodySchema = {
-          type: 'object',
-          required: required.length ? required : undefined,
-          properties: fromPairs(bodyPropertySchemas)
+        // only one body schema is allowed per operation
+        if (bodyPropertySchemas.length > 1) {
+          console.log(
+            chalk.red(
+              `The operation ${chalk.bold(methodInfo.operationId)} has multiple body schemas defined. Each operation may only have one.`
+            )
+          )
+          process.exit(1)
         }
+        const bodySchema = bodyPropertySchemas[0][1]
         const validateBody = ajv.compile(bodySchema)
         validators.push((req, res, next) => {
           const isValid = validateBody(req.body)

--- a/lib/validate-request.js
+++ b/lib/validate-request.js
@@ -3,6 +3,7 @@ const Ajv = require('ajv')
 const chalk = require('chalk')
 const pick = require('lodash/pick')
 const fromPairs = require('lodash/fromPairs')
+const loadRefs = require('./utils/load-refs')
 
 module.exports = (
   apiDefinition,
@@ -11,124 +12,122 @@ module.exports = (
   requestValidationErrorHandler
 ) => {
   const ajv = new Ajv(Object.assign({}, {removeAdditional: true}, ajvOptions))
-
-  for (let definitionSchema in apiDefinition.definitions) {
-    ajv.addSchema(apiDefinition.definitions[definitionSchema], '#/definitions/' + definitionSchema)
-  }
-
   const requestValidationRouter = express.Router({mergeParams: true})
+  loadRefs({ajv, apiDefinition})
 
   for (let path in apiDefinition.paths) {
     for (let method in apiDefinition.paths[path]) {
-      const methodInfo = apiDefinition.paths[path][method]
-      const validators = []
+      // check that the method exists, filters out paramers & $ref
+      if (requestValidationRouter[method]) {
+        const methodInfo = apiDefinition.paths[path][method]
+        const validators = []
 
-      // validate request body
-      const bodyPropertySchemas = (methodInfo.parameters || [])
-        .filter(inBody)
-        .map(param => {
-          const schema = Object.assign({}, param.schema || {})
-          return [param.name, schema]
-        })
-        
-      if (bodyPropertySchemas.length) {
-        // only one body schema is allowed per operation
-        if (bodyPropertySchemas.length > 1) {
-          console.log(
-            chalk.red(
-              `The operation ${chalk.bold(methodInfo.operationId)} has multiple body schemas defined. Each operation may only have one.`
+        // validate request body
+        const bodyPropertySchemas = (methodInfo.parameters || [])
+          .filter(inBody)
+          .map(param => {
+            const schema = Object.assign({}, param.schema || {})
+            return [param.name, schema]
+          })
+
+        if (bodyPropertySchemas.length) {
+          // only one body schema is allowed per operation
+          if (bodyPropertySchemas.length > 1) {
+            console.log(
+              chalk.red(
+                `The operation ${chalk.bold(methodInfo.operationId)} has multiple body schemas defined. Each operation may only have one.`
+              )
             )
-          )
-          process.exit(1)
-        }
-        const bodySchema = bodyPropertySchemas[0][1]
-        const validateBody = ajv.compile(bodySchema)
-        validators.push((req, res, next) => {
-          const isValid = validateBody(req.body)
-          if (!isValid) {
-            requestValidationErrorHandler(req, res, validateBody.errors, next)
-            return false
+            process.exit(1)
           }
-          return true
-        })
-      }
+          const bodySchema = bodyPropertySchemas[0][1]
+          const validateBody = ajv.compile(bodySchema)
+          validators.push((req, res, next) => {
+            const isValid = validateBody(req.body)
+            if (!isValid) {
+              requestValidationErrorHandler(req, res, validateBody.errors, next)
+              return false
+            }
+            return true
+          })
+        }
 
-      const nonBodySchemaFields = [
-        'type',
-        'items',
-        'exclusiveMaximum',
-        'minimum',
-        'exclusiveMinimum',
-        'maxLength',
-        'minLength',
-        'pattern',
-        'maxItems',
-        'minItems',
-        'uniqueItems',
-        'enum',
-        'multipleOf'
-      ]
+        const nonBodySchemaFields = [
+          'type',
+          'items',
+          'exclusiveMaximum',
+          'minimum',
+          'exclusiveMinimum',
+          'maxLength',
+          'minLength',
+          'pattern',
+          'maxItems',
+          'minItems',
+          'uniqueItems',
+          'enum',
+          'multipleOf'
+        ]
 
-      // validate query params
-      const queryParamsSchemas = (methodInfo.parameters || [])
-        .filter(inQuery)
-        .map(param => {
-          const schema = Object.assign({}, pick(param, nonBodySchemaFields))
-          return [param.name, schema]
-        })
-      if (queryParamsSchemas.length) {
-        const required = methodInfo.parameters
+        // validate query params
+        const queryParamsSchemas = (methodInfo.parameters || [])
           .filter(inQuery)
-          .filter(param => param.required)
-          .map(param => param.name)
-        const queryParamsSchema = {
-          type: 'object',
-          required: required.length ? required : undefined,
-          properties: fromPairs(queryParamsSchemas)
-        }
-        const validateQueryParams = ajv.compile(queryParamsSchema)
-        validators.push((req, res, next) => {
-          const valid = validateQueryParams(req.query)
-          if (!valid) {
-            requestValidationErrorHandler(
-              req,
-              res,
-              validateQueryParams.errors,
-              next
-            )
-            return false
+          .map(param => {
+            const schema = Object.assign({}, pick(param, nonBodySchemaFields))
+            return [param.name, schema]
+          })
+          
+        if (queryParamsSchemas.length) {
+          const required = methodInfo.parameters
+            .filter(inQuery)
+            .filter(param => param.required)
+            .map(param => param.name)
+          const queryParamsSchema = {
+            type: 'object',
+            required: required.length ? required : undefined,
+            properties: fromPairs(queryParamsSchemas)
           }
-          return true
-        })
-      }
-
-      const validateRequest = (req, res, next) => {
-        const validations = validators.map(validator => validator(req, res))
-        const allWereValid = validations.every(validation => validation)
-        if (allWereValid) {
-          next()
-        }
-      }
-
-      const expressFriendlyPath = path
-        .replace(/\/{/g, '/:')
-        .replace(new RegExp('}', 'g'), '')
-        
-        if (requestValidationRouter[method]) {
-          requestValidationRouter[method](expressFriendlyPath, validateRequest)
+          const validateQueryParams = ajv.compile(queryParamsSchema)
+          validators.push((req, res, next) => {
+            const valid = validateQueryParams(req.query)
+            if (!valid) {
+              requestValidationErrorHandler(
+                req,
+                res,
+                validateQueryParams.errors,
+                next
+              )
+              return false
+            }
+            return true
+          })
         }
 
-      if (methodInfo.operationId) {
-        if (!operations[methodInfo.operationId]) {
-          console.log(
-            chalk.red(
-              `The operation ${chalk.bold(methodInfo.operationId)} is missing`
+        const validateRequest = (req, res, next) => {
+          const validations = validators.map(validator => validator(req, res))
+          const allWereValid = validations.every(validation => validation)
+          if (allWereValid) {
+            next()
+          }
+        }
+
+        const expressFriendlyPath = path
+          .replace(/\/{/g, '/:')
+          .replace(new RegExp('}', 'g'), '')
+          
+        requestValidationRouter[method](expressFriendlyPath, validateRequest)
+
+        if (methodInfo.operationId) {
+          if (!operations[methodInfo.operationId]) {
+            console.log(
+              chalk.red(
+                `The operation ${chalk.bold(methodInfo.operationId)} is missing`
+              )
             )
-          )
-          process.exit(1)
+            process.exit(1)
+          }
+          const routeController = operations[methodInfo.operationId]
+          requestValidationRouter[method](expressFriendlyPath, routeController)
         }
-        const routeController = operations[methodInfo.operationId]
-        requestValidationRouter[method](expressFriendlyPath, routeController)
       }
     }
   }

--- a/lib/validate-response.js
+++ b/lib/validate-response.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const Ajv = require('ajv')
+const loadRefs = require('./utils/load-refs')
 
 module.exports = (
   apiDefinition,
@@ -8,26 +9,30 @@ module.exports = (
 ) => {
   const ajv = new Ajv(Object.assign({}, {removeAdditional: true}, ajvOptions))
   const responseValidationRouter = express.Router({mergeParams: true})
+  loadRefs({ajv, apiDefinition})
+  
   for (let path in apiDefinition.paths) {
     for (let method in apiDefinition.paths[path]) {
-      const methodInfo = apiDefinition.paths[path][method]
+      // check that the method exists, filters out paramers & $ref
+      if (responseValidationRouter[method]) {
+        const methodInfo = apiDefinition.paths[path][method]
+        const validators = {}
+        Object.keys(methodInfo.responses).forEach(statusCode => {
+          if (methodInfo.responses[statusCode].schema) {
+            validators[statusCode] = ajv.compile(
+              methodInfo.responses[statusCode].schema
+            )
+          }
+        })
 
-      const validators = {}
-      Object.keys(methodInfo.responses).forEach(statusCode => {
-        if (methodInfo.responses[statusCode].schema) {
-          validators[statusCode] = ajv.compile(
-            methodInfo.responses[statusCode].schema
-          )
-        }
-      })
-
-      const expressFriendlyPath = path
-        .replace(/\/{/g, '/:')
-        .replace(new RegExp('}', 'g'), '')
-      responseValidationRouter[method](
-        expressFriendlyPath,
-        injectResponseValidator(validators, responseValidationErrorHandler)
-      )
+        const expressFriendlyPath = path
+          .replace(/\/{/g, '/:')
+          .replace(new RegExp('}', 'g'), '')
+        responseValidationRouter[method](
+          expressFriendlyPath,
+          injectResponseValidator(validators, responseValidationErrorHandler)
+        )
+      }
     }
   }
   return responseValidationRouter


### PR DESCRIPTION
* most of the changes are just whitespace.

Main change changes how the request body params are being read in. There can only be one body and it needs to define a proper schema. I've changed the tests files as well to reflect the spec

From: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md
> Body - The payload that's appended to the HTTP request. Since there can only be one payload, there can only be one body parameter. The name of the body parameter has no effect on the parameter itself and is used for documentation purposes only. Since Form parameters are also in the payload, body and form parameters cannot exist together for the same operation.

Let me know if I missed something 😄 